### PR TITLE
Binning functions

### DIFF
--- a/blpdm/chem.py
+++ b/blpdm/chem.py
@@ -6,7 +6,7 @@ import numpy as np
 import xarray as xr
 from scipy import stats
 
-from .utils import auto_bins_2d
+from .utils import auto_bins_xy
 from .utils import calc_t_out
 from .utils import load_p
 
@@ -336,7 +336,7 @@ def calc_gridded_conc_canola(ds):
     dx = X[1] - X[0]
     dy = Y[1] - Y[0]
     pos = (X, Y)
-    bins = auto_bins_2d(pos)
+    bins = auto_bins_xy(pos)
 
     # 4. Calculate concentrations from particle concentration field
     #    and speciated fv_0

--- a/blpdm/chem.py
+++ b/blpdm/chem.py
@@ -425,14 +425,14 @@ def calc_gridded_conc_canola(ds):
 
     ds = xr.Dataset(
         coords={
-            "x": ("x", x, {"units": "m", "long_name": "x (bin edges)"}),
-            "y": ("y", y, {"units": "m", "long_name": "y (bin edges)"}),
-            "xc": ("xc", xc, {"units": "m", "long_name": "x (bin centers)"}),
-            "yc": ("yc", yc, {"units": "m", "long_name": "y (bin centers)"}),
+            "xe": ("xe", x, {"units": "m", "long_name": "x (bin edge)"}),
+            "ye": ("ye", y, {"units": "m", "long_name": "y (bin edge)"}),
+            "x": ("x", xc, {"units": "m", "long_name": "x (bin center)"}),
+            "y": ("y", yc, {"units": "m", "long_name": "y (bin center)"}),
             "spc": ("spc", spc_sorted, {"long_name": "chemical species"}),
         },
         data_vars={
-            vn: (("spc", "xc", "yc"), values, {
+            vn: (("spc", "x", "y"), values, {
                 "units": units[vn], "long_name": long_names[vn],
             })
             for vn, values in res_agg.items()

--- a/blpdm/chem.py
+++ b/blpdm/chem.py
@@ -6,7 +6,7 @@ import numpy as np
 import xarray as xr
 from scipy import stats
 
-from .utils import auto_grid
+from .utils import auto_bins_2d
 from .utils import calc_t_out
 from .utils import load_p
 
@@ -336,7 +336,7 @@ def calc_gridded_conc_canola(ds):
     dx = X[1] - X[0]
     dy = Y[1] - Y[0]
     pos = (X, Y)
-    bins = auto_grid(pos)
+    bins = auto_bins_2d(pos)
 
     # 4. Calculate concentrations from particle concentration field
     #    and speciated fv_0

--- a/blpdm/plots.py
+++ b/blpdm/plots.py
@@ -266,11 +266,7 @@ def conc_xline(ds, spc="apinene", y=0., *,
     spc_to_plot = ds.spc.values if spc == "all" else [spc]
 
     # Define bins (edges)
-    Np = p["Np_tot"]  # TODO: the part for xe here it taken from utils.auto_grid
-    xbar, xstd = X.mean(), X.std()
-    mult = 2.0
-    nx = min(np.sqrt(Np).astype(int), 100)
-    xe = np.linspace(xbar - mult * xstd, xbar + mult * xstd, nx + 1)
+    xe = utils._auto_bins_1d(X, nx_max=100, std_mult=2.0, method="sqrt")
     ye = np.r_[y - 0.5*dy, y + 0.5*dy]
     # ze = np.r_[z - 0.5*dz, z + 0.5*dz]
     bins = [xe, ye]

--- a/blpdm/plots.py
+++ b/blpdm/plots.py
@@ -218,7 +218,7 @@ def conc_2d(ds, spc="apinene",
 
     if "x" not in ds.dims:
         # We were passed the particles dataset, need to do the binning
-        binned = utils.bin_c_xy(X, Y, conc, bins=bins)
+        binned = utils.bin_values_xy(X, Y, conc, bins=bins)
     else:
         raise NotImplementedError("already binned?")
 
@@ -229,9 +229,9 @@ def conc_2d(ds, spc="apinene",
     )
 
     if plot_type == "pcolor":
-        im = ax.pcolormesh(binned.xe, binned.ye, binned.c, cmap=cmap, norm=norm)
+        im = ax.pcolormesh(binned.xe, binned.ye, binned.v, cmap=cmap, norm=norm)
     elif plot_type == "contourf":
-        im = ax.contourf(binned.x, binned.y, binned.c, levels, cmap=cmap, norm=norm, locator=locator)
+        im = ax.contourf(binned.x, binned.y, binned.v, levels, cmap=cmap, norm=norm, locator=locator)
     else:
         raise ValueError("`plot_type` should be 'pcolor' or 'contourf'")
 
@@ -278,12 +278,12 @@ def conc_xline(ds, spc="apinene", y=0., *,
     for spc in spc_to_plot:
         spc_display_name = chemical_species_data[spc]["display_name"]
         conc = ds.f_r.sel(spc=spc).values
-        binned = utils.bin_c_xy(X, Y, conc, bins=bins)
-        ax.plot(binned.x, binned.c.squeeze(), label=spc_display_name if label is None else label)
+        binned = utils.bin_values_xy(X, Y, conc, bins=bins)
+        ax.plot(binned.x, binned.v.squeeze(), label=spc_display_name if label is None else label)
 
     for (xs, ys) in p["source_positions"]:
         if abs(ys - y) <= 5:
-            ax.plot(xs, np.nanmin(binned.c), **_SOURCE_MARKER_PROPS)
+            ax.plot(xs, np.nanmin(binned.v), **_SOURCE_MARKER_PROPS)
 
     if legend:
         fig.legend(ncol=2, fontsize="small", title="Chemical species" if legend_title is None else legend_title)
@@ -387,7 +387,7 @@ def final_pos_hist2d(
     fig, ax = plt.subplots(num=num)
 
     if bins == "auto":
-        bins = utils.auto_grid([x, y])
+        bins = utils.auto_bins_2d([x, y])
 
     if log_cnorm:
         norm = mpl.colors.LogNorm(vmin=1.0, vmax=vmax)

--- a/blpdm/utils.py
+++ b/blpdm/utils.py
@@ -341,3 +341,18 @@ def maybe_new_figure(try_num: str, ax=None):
         fig = ax.get_figure()
 
     return fig, ax
+
+
+def check_sdim(sdim: str):
+    if len(sdim) not in (2, 3) or any(dim1 not in ("x", "y", "z") for dim1 in sdim):
+        raise ValueError("for `sdim`, pick 2 or 3 from 'x', 'y', and 'z'. For example, 'xy'.")
+
+
+def dims_from_sdim(sdim: str):
+    check_sdim(sdim)  # first validate
+    if sdim.lower() in ("xyz", "3d", "3-d"):
+        dims = list("xyz")
+    else:
+        dims = list(sdim.lower())
+
+    return dims

--- a/blpdm/utils.py
+++ b/blpdm/utils.py
@@ -108,8 +108,20 @@ def s_sample_size(p, *, N_p_only=False):
 # TODO: fn to pre-process state for plots, removing data outside certain limits or with too high vel components ?
 
 
-# TODO: reduce the doubled code for x and y below by defining this fn
-# def _auto_grid_np_1d(a):
+def _auto_bins_1d(x, *, nx_max, std_mult, method):
+    x_bar, x_std = x.mean(), x.std()
+    if std_mult is not None:
+        x_range = x_bar - std_mult * x_std, x_bar + std_mult * x_std
+    else:
+        x_range = None
+
+    x_edges = np.histogram_bin_edges(x, bins=method, range=x_range)
+
+    if x_edges.size > nx_max + 1:
+        x_edges = np.linspace(*x_range, nx_max+1)
+
+    return x_edges
+
 
 def auto_bins_2d(positions, *,
     nxy_max: int = 100,
@@ -141,18 +153,11 @@ def auto_bins_2d(positions, *,
     Y = pos[:,1]
 
     # TODO: optional `z_range=` arg for including certain range of heights, with defaults np.inf or None
+    # TODO: optional centering cell over certain x, y value (like 0, 0)
 
-    x_bar, x_std = X.mean(), X.std()
-    x_range = x_bar - std_mult * x_std, x_bar + std_mult * x_std if std_mult is not None else None
-    x_edges = np.histogram_bin_edges(X, bins=method, range=x_range)
-    if x_edges.size > nxy_max + 1:
-        x_edges = np.linspace(*x_range, nxy_max+1)
-
-    y_bar, y_std = Y.mean(), Y.std()
-    y_range = y_bar - std_mult * y_std, y_bar + std_mult * y_std if std_mult is not None else None
-    y_edges = np.histogram_bin_edges(Y, bins=method, range=y_range)
-    if y_edges.size > nxy_max + 1:
-        y_edges = np.linspace(*x_range, nxy_max+1)
+    kwargs_1d = dict(nx_max=nxy_max, std_mult=std_mult, method=method)
+    x_edges = _auto_bins_1d(X, **kwargs_1d)
+    y_edges = _auto_bins_1d(Y, **kwargs_1d)
 
     return [x_edges, y_edges]  # bins
 

--- a/blpdm/utils.py
+++ b/blpdm/utils.py
@@ -361,15 +361,20 @@ def maybe_new_figure(try_num: str, ax=None):
 
 
 def check_sdim(sdim: str):
-    if len(sdim) not in (2, 3) or any(dim1 not in ("x", "y", "z") for dim1 in sdim):
-        raise ValueError("for `sdim`, pick 2 or 3 from 'x', 'y', and 'z'. For example, 'xy'.")
+    valid_sdim = ["xy", "xz", "yz", "xyz", "3d", "3-d"]
+    if sdim not in valid_sdim:
+        raise ValueError(
+            "for `sdim`, pick 2 or 3 from 'x', 'y', and 'z'. For example, 'xy'. "
+            f"The full set of valid options is {valid_sdim}. "
+            "The last two are aliases for 'xyz'."
+        )
 
 
 def dims_from_sdim(sdim: str):
     check_sdim(sdim)  # first validate
-    if sdim.lower() in ("xyz", "3d", "3-d"):
+    if sdim in ("xyz", "3d", "3-d"):
         dims = list("xyz")
     else:
-        dims = list(sdim.lower())
+        dims = list(sdim)
 
     return dims

--- a/blpdm/utils.py
+++ b/blpdm/utils.py
@@ -214,7 +214,9 @@ def bin_ds_xy(ds, *, variables="all", bins="auto"):
     if bins == "auto":
         bins = auto_bins_xy(pos)
 
-    res = {}
+    # Compute statistics, using `binned_statistic_dd` so we can pass the previous
+    # result for efficiency.
+    res = {}  # {vn: {stat: ...}, ...}
     ret = None  # for first run we don't have a result yet
     stats_to_calc = ["mean", "median", "std", "count"]  # note sum can be recovered with mean and particle count
     for vn in vns:
@@ -230,6 +232,9 @@ def bin_ds_xy(ds, *, variables="all", bins="auto"):
             )
             rets[stat] = ret
         res[vn] = rets
+
+        if vn == vns[0]:
+            stats_to_calc.remove("count")  # only need it once
 
     # Grid
     x, y = ret.bin_edges[0], ret.bin_edges[1]

--- a/blpdm/utils.py
+++ b/blpdm/utils.py
@@ -131,7 +131,7 @@ def auto_bins(positions, sdim="xy", *,
     std_mult: float = 2.0,
     method: str = "auto",
 ):
-    """Determine bin edges for a 2-d horizontal grid
+    """Determine bin edges for a 2- or 3-d horizontal grid
     that lets us focus on where most of the data is.
 
     Parameters
@@ -140,7 +140,7 @@ def auto_bins(positions, sdim="xy", *,
         Container of 1-D arrays (in x,y[,z] order)
         OR single NumPy array where columns are x,y[,z].
     nbins_max_1d
-        Maximum number of bins in either direction (x or y).
+        Maximum number of bins in any direction/dim.
     std_mult
         Standard deviation multiplier.
         Increase to capture more of the domain.

--- a/blpdm/utils.py
+++ b/blpdm/utils.py
@@ -11,8 +11,6 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 
-# TODO: create fn to compare two sets of parameters and point out the changes
-
 
 def get_open_fig_labels():
     return [plt.figure(num).get_label() for num in plt.get_fignums()]

--- a/blpdm/utils.py
+++ b/blpdm/utils.py
@@ -179,7 +179,7 @@ def bin_values_xy(x, y, values, *, bins="auto", stat="median"):
     conc_p_rel = (H / H.max()).T  # TODO: really should divide by level at source (closest bin?)
 
     # 2. In-particle values in each bin
-    ret = stats.binned_statistic_2d(x, y, values, statistic="median", bins=bins)
+    ret = stats.binned_statistic_2d(x, y, values, statistic=stat, bins=bins)
     v0 = ret.statistic.T  # it is returned with dim (nx, ny), we need y to be rows (dim 0)
     xe = ret.x_edge
     ye = ret.y_edge


### PR DESCRIPTION
New function `bin_ds` bins a particles dataset in 3 dims or any 2. Currently doesn't work for trajectory runs, which have a time dimension. In support of this, the auto binning function also works for the same set of dim choices.